### PR TITLE
Use stable version of `embedded-hal-mock`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,4 @@ embedded-hal = "1"
 bitflags = "2.4"
 
 [dev-dependencies]
-embedded-hal-mock = { version = "0.10" }
-
-[patch.crates-io]
-embedded-hal-mock = { git = "https://github.com/dbrgn/embedded-hal-mock" }
+embedded-hal-mock = "0.10"


### PR DESCRIPTION
Needs to wait for new release: https://github.com/dbrgn/embedded-hal-mock/pull/111